### PR TITLE
Fix capitalisation of mesh file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Par défaut, sous Windows 64bits :
 - Les paramètres de l'imprimante :
   - `.\resources\definitions\dagoma_discoeasy200.def.json`
 - Le modèle 3D de l'imprimante :
-  - `.\resources\meshes\dagoma_discoeasy200_plateform.STL`
+  - `.\resources\meshes\dagoma_discoeasy200_plateform.stl`
 - Les paramètres de qualité d'impression :
   - `.\resources\quality\dagoma_discoeasy200\*.inst.cfg`
 - Les paramètres des différents filaments :


### PR DESCRIPTION
I came across this small mistake. Some file systems are sensitive to caps, so this corrects the instructions.